### PR TITLE
Removed files not needed in bower packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,16 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "src",
+    "Gruntfile.js",
+    "webpack.conf.js",
+    "webpack.conf.minify.js",
+    "karma.conf.js",
+    "karma.conf.cs.js",
+    "other",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md"
   ],
   "dependencies": {
     "angular": ">=1.2.x",

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "webpack.conf.js",
     "webpack.conf.minify.js",
     "karma.conf.js",
-    "karma.conf.cs.js",
+    "karma.conf.ci.js",
     "other",
     "CONTRIBUTING.md",
     "CHANGELOG.md"


### PR DESCRIPTION
My goal is to make the bower packages smaller by ignoring these files:
"src", "Gruntfile.js",  "webpack.conf.js", "webpack.conf.minify.js", "karma.conf.js", "karma.conf.cs.js", "other",
"CONTRIBUTING.md", "CHANGELOG.md"