### PR TITLE
Adding optional Bootstrap sr-only class to label

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ NOTE: All of these properties will be under the `templateOptions` property as of
 >`undefined`
 
 ---
+##### labelSrOnly (boolean)
+>`labelSrOnly` is used to add the sr-only class to a label so it will hide on non-screen-readers
+
+###### Default
+>`undefined`
+
+---
 ##### required (boolean)
 >`required` is used to add the required attribute to a form field.
 

--- a/src/wrappers/index.js
+++ b/src/wrappers/index.js
@@ -9,7 +9,8 @@ export default ngModule => {
 	      apiCheck: check => ({
 	        templateOptions: {
             label: check.string,
-            required: check.bool.optional
+            required: check.bool.optional,
+            labelSrOnly: check.bool.optional,
 	        }
 	      })
       },

--- a/src/wrappers/label.html
+++ b/src/wrappers/label.html
@@ -1,5 +1,5 @@
 <div>
-  <label for="{{id}}" class="control-label" ng-if="to.label">
+  <label for="{{id}}" class="control-label {{to.labelSrOnly ? 'sr-only' : ''}}" ng-if="to.label">
     {{to.label}}
     {{to.required ? '*' : ''}}
   </label>


### PR DESCRIPTION
when sr-only is a class on the label, the label will hide for
non-screen-reader clients

added labelSrOnly to common properties section