### PR TITLE
fix(select input, readme): Handle object options in select input

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ _Example radio field_
 >The select field allows selection via dropdown using the select element.
 
 ##### options (array, required)
->`options` is an array of options for the select form field to display. Each option should be an object with a `name`(string). You may optionally add a `group` to some or all of your options.
+>`options` it can be an array or an object:
+  - an array of options  for the select form field to display. Each option should be an object with a `name`(string). You may optionally add a `group` to some or all of your options.
+  - an object with key an value pairs used in combination with ngOptions ([Example](http://jsbin.com/gikiji/3/edit?js,output)).
 
 ##### labelProp (string, optional)
 >`labelProp` is what is used for what is shown to the user. Defaults to `name`

--- a/src/types/select.js
+++ b/src/types/select.js
@@ -21,7 +21,7 @@ export default  ngModule => {
       },
       apiCheck: check => ({
         templateOptions: {
-          options: check.arrayOf(check.object),
+          options: check.oneOfType([check.arrayOf(check.object), check.objectOf(check.string)]),
           optionsAttr: check.string.optional,
           labelProp: check.string.optional,
           valueProp: check.string.optional,


### PR DESCRIPTION
You can pass an object with key:value pairs for a select options instead only arrays. You also need

#107